### PR TITLE
Implement video splitting and timeline functionality

### DIFF
--- a/VideoEditor/MainWindow.axaml
+++ b/VideoEditor/MainWindow.axaml
@@ -12,10 +12,11 @@
         <DockPanel Grid.Column="0">
             <StackPanel DockPanel.Dock="Top" Orientation="Vertical">
                 <Button Content="Add Media" Margin="5" Click="AddMediaButton_Click"/>
+                <Button x:Name="SplitButton" Content="Split Clip" Margin="5,0,5,5" Click="SplitButton_Click"/>
                 <Button x:Name="ExportButton" Content="Export Video" Margin="5,0,5,5" Click="ExportButton_Click"/>
             </StackPanel>
-            <ListBox x:Name="MediaListBox" Margin="5" SelectionChanged="MediaListBox_SelectionChanged">
-                <!-- Media file paths will be displayed here -->
+            <ListBox x:Name="MediaListBox" Margin="5" SelectionChanged="MediaListBox_SelectionChanged" DisplayMemberBinding="{Binding DisplayName}">
+                <!-- VideoClip objects will be displayed here -->
             </ListBox>
         </DockPanel>
 
@@ -26,7 +27,26 @@
 
             <!-- Timeline Panel -->
             <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="0,1,0,0">
-                <TextBlock Text="Timeline" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                <ScrollViewer HorizontalScrollBarVisibility="Auto">
+                    <ItemsControl x:Name="TimelineItemsControl">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <!-- A simple representation of a video clip -->
+                                <Border BorderBrush="Black" BorderThickness="1" Margin="2" Background="LightSkyBlue" Height="60">
+                                    <StackPanel Orientation="Vertical" Margin="5">
+                                        <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding Duration, StringFormat='Duration: {0:hh\\:mm\\:ss}'}"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
             </Border>
         </Grid>
     </Grid>

--- a/VideoEditor/MainWindow.axaml.cs
+++ b/VideoEditor/MainWindow.axaml.cs
@@ -5,16 +5,17 @@ using System.Collections.ObjectModel;
 using LibVLCSharp.Shared;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Xabe.FFmpeg;
 
 namespace VideoEditor;
 
 public partial class MainWindow : Window
 {
-    private readonly ObservableCollection<string> _mediaItems = new();
+    private readonly ObservableCollection<VideoClip> _timelineClips = new();
     private readonly LibVLC _libVLC;
     private readonly MediaPlayer _mediaPlayer;
-    private Media? _currentMedia; // <-- Added to manage media lifetime
+    private Media? _currentMedia;
 
     public MainWindow()
     {
@@ -24,7 +25,10 @@ public partial class MainWindow : Window
         _libVLC = new LibVLC();
         _mediaPlayer = new MediaPlayer(_libVLC);
         VideoView.MediaPlayer = _mediaPlayer;
-        MediaListBox.ItemsSource = _mediaItems;
+
+        // Bind collections to the UI elements
+        MediaListBox.ItemsSource = _timelineClips;
+        TimelineItemsControl.ItemsSource = _timelineClips;
     }
 
     protected override void OnClosed(EventArgs e)
@@ -46,58 +50,142 @@ public partial class MainWindow : Window
             AllowMultiple = true,
             FileTypeFilter = new[]
             {
-                new FilePickerFileType("Video Files")
-                {
-                    Patterns = new[] { "*.mp4", "*.mkv", "*.avi", "*.mov" }
-                },
+                new FilePickerFileType("Video Files") { Patterns = new[] { "*.mp4", "*.mkv", "*.avi", "*.mov" } },
                 FilePickerFileTypes.All
             }
         });
 
-        if (files.Count > 0)
+        foreach (var file in files)
         {
-            foreach (var file in files)
+            var path = file.Path.LocalPath;
+            try
             {
-                _mediaItems.Add(file.Path.LocalPath);
+                var mediaInfo = await FFmpeg.GetMediaInfo(path);
+                var duration = mediaInfo.Duration;
+                var clip = new VideoClip(path, TimeSpan.Zero, duration);
+                _timelineClips.Add(clip);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error getting media info for {path}: {ex.Message}");
+                // Optionally, show an error to the user
             }
         }
     }
 
     public void MediaListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (e.AddedItems.Count > 0 && e.AddedItems[0] is string path)
+        if (e.AddedItems.Count > 0 && e.AddedItems[0] is VideoClip clip)
         {
-            // Dispose the previous media object
             _currentMedia?.Dispose();
 
-            // Create and play the new media
-            _currentMedia = new Media(_libVLC, new Uri(path));
+            // By default, VLC plays the whole file. We need to tell it to play just the clip's segment.
+            // We can do this with media options.
+            _currentMedia = new Media(_libVLC, new Uri(clip.SourcePath),
+                $":start-time={clip.TrimStart.TotalSeconds}",
+                $":stop-time={clip.TrimEnd.TotalSeconds}");
+
             _mediaPlayer.Play(_currentMedia);
-            // DO NOT dispose _currentMedia here
         }
+    }
+
+    public void SplitButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (MediaListBox.SelectedItem is not VideoClip selectedClip)
+        {
+            Console.WriteLine("Please select a clip to split.");
+            return;
+        }
+
+        var playbackTime = TimeSpan.FromMilliseconds(_mediaPlayer.Time);
+        // The actual split time within the source video's full timeline
+        var splitPoint = selectedClip.TrimStart + playbackTime;
+
+        // Basic validation: ensure the split point is within the clip's duration and not at the edges.
+        if (splitPoint <= selectedClip.TrimStart || splitPoint >= selectedClip.TrimEnd)
+        {
+            Console.WriteLine("Split point must be within the clip.");
+            return;
+        }
+
+        var originalIndex = _timelineClips.IndexOf(selectedClip);
+        if (originalIndex == -1) return;
+
+        // Create the two new clips
+        var clipA = new VideoClip(selectedClip.SourcePath, selectedClip.TrimStart, splitPoint);
+        var clipB = new VideoClip(selectedClip.SourcePath, splitPoint, selectedClip.TrimEnd);
+
+        // Replace the old clip with the two new ones
+        _timelineClips.RemoveAt(originalIndex);
+        _timelineClips.Insert(originalIndex, clipA);
+        _timelineClips.Insert(originalIndex + 1, clipB);
+
+        Console.WriteLine($"Clip '{selectedClip.DisplayName}' split into two clips at {splitPoint}.");
     }
 
     public async void ExportButton_Click(object sender, RoutedEventArgs e)
     {
-        if (_mediaItems.Count < 2)
+        if (_timelineClips.Count == 0)
         {
-            Console.WriteLine("Please add at least two videos to concatenate.");
+            Console.WriteLine("Please add at least one video to the timeline.");
             return;
         }
 
         var outputPath = "output.mp4";
-        Console.WriteLine("Starting video concatenation...");
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "VideoEditor_Temp", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDirectory);
+
+        Console.WriteLine("Starting video export...");
+        ExportButton.IsEnabled = false;
 
         try
         {
-            IConversion conversion = await FFmpeg.Conversions.FromSnippet.Concatenate(outputPath, _mediaItems.ToArray());
-            await conversion.Start();
+            var tempClipPaths = new List<string>();
+            for (int i = 0; i < _timelineClips.Count; i++)
+            {
+                var clip = _timelineClips[i];
+                var tempClipPath = Path.Combine(tempDirectory, $"{i}.mp4");
 
-            Console.WriteLine($"Concatenation finished! Video saved to: {outputPath}");
+                Console.WriteLine($"Trimming clip {i+1}/{_timelineClips.Count}...");
+
+                var conversion = FFmpeg.Conversions.New()
+                    .AddParameter($"-ss {clip.TrimStart.TotalSeconds}")
+                    .AddParameter($"-to {clip.TrimEnd.TotalSeconds}")
+                    .AddParameter($"-i \"{clip.SourcePath}\"")
+                    .AddParameter("-c:v copy -c:a copy") // Fast, no re-encoding
+                    .SetOutput(tempClipPath);
+
+                await conversion.Start();
+                tempClipPaths.Add(tempClipPath);
+            }
+
+            Console.WriteLine("All clips trimmed. Concatenating...");
+
+            if (tempClipPaths.Count > 1)
+            {
+                IConversion conversion = await FFmpeg.Conversions.FromSnippet.Concatenate(outputPath, tempClipPaths.ToArray());
+                await conversion.Start();
+            }
+            else if (tempClipPaths.Count == 1)
+            {
+                // If there's only one clip, we just move the trimmed file.
+                File.Move(tempClipPaths.First(), outputPath, true);
+            }
+
+            Console.WriteLine($"Export finished! Video saved to: {outputPath}");
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"An error occurred during concatenation: {ex.Message}");
+            Console.WriteLine($"An error occurred during export: {ex.Message}");
+        }
+        finally
+        {
+            // Clean up temporary files
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+            ExportButton.IsEnabled = true;
         }
     }
 }

--- a/VideoEditor/VideoClip.cs
+++ b/VideoEditor/VideoClip.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+
+namespace VideoEditor;
+
+public class VideoClip
+{
+    /// <summary>
+    /// Gets the full path to the source media file.
+    /// </summary>
+    public string SourcePath { get; }
+
+    /// <summary>
+    /// Gets the time in the source media file where this clip begins.
+    /// </summary>
+    public TimeSpan TrimStart { get; set; }
+
+    /// <summary>
+    /// Gets the time in the source media file where this clip ends.
+    /// </summary>
+    public TimeSpan TrimEnd { get; set; }
+
+    /// <summary>
+    /// Gets the duration of this clip.
+    /// </summary>
+    public TimeSpan Duration => TrimEnd - TrimStart;
+
+    /// <summary>
+    /// Gets a user-friendly display name for the clip.
+    /// </summary>
+    public string DisplayName { get; }
+
+    public VideoClip(string sourcePath, TimeSpan trimStart, TimeSpan trimEnd)
+    {
+        if (!File.Exists(sourcePath))
+        {
+            throw new FileNotFoundException("The source video file was not found.", sourcePath);
+        }
+
+        if (trimStart < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(trimStart), "TrimStart cannot be negative.");
+        }
+
+        if (trimEnd <= trimStart)
+        {
+            throw new ArgumentException("TrimEnd must be greater than TrimStart.", nameof(trimEnd));
+        }
+
+        SourcePath = sourcePath;
+        TrimStart = trimStart;
+        TrimEnd = trimEnd;
+        DisplayName = Path.GetFileName(sourcePath);
+    }
+
+    /// <summary>
+    /// Clones the current video clip with a new start and end time.
+    /// </summary>
+    public VideoClip CloneWithNewTimes(TimeSpan newTrimStart, TimeSpan newTrimEnd)
+    {
+        return new VideoClip(this.SourcePath, newTrimStart, newTrimEnd);
+    }
+}


### PR DESCRIPTION
Based on the user's request, add basic video editing features.

Key changes:
- Introduce a `VideoClip` class to manage video segments (source, start time, end time).
- Update the UI to implement a timeline that visually displays clips.
- Add a feature to split a selected clip into two based on the preview's playback time.
- Improve the export function to accurately reflect the trimming information of clips on the timeline when generating the final video.

This adds the first core editing functionality to the MVP of the Windows Movie Maker-like video editing application.