### PR TITLE
feat: Add rotation, speed control, and image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,29 @@
-# VideoEditor MVP
+# ビデオエディタ MVP
 
-This is an MVP (Minimum Viable Product) for a video editor application built with .NET 8 and Avalonia UI.
+これは、.NET 8とAvalonia UIで構築されたビデオエディタアプリケーションのMVP（Minimum Viable Product）です。
 
-## Features
+## 機能
 
-*   **Media Loading:** Add multiple video files to a media list.
-*   **Video Preview:** Select a video from the list to play it in the preview pane. (Powered by LibVLCSharp)
-*   **Video Concatenation:** Export all videos in the media list into a single `output.mp4` file. (Powered by FFmpeg)
+*   **メディア読み込み:** 複数のビデオファイルをメディアリストに追加します。
+*   **ビデオプレビュー:** リストからビデオを選択すると、プレビューペインで再生されます。（LibVLCSharpを利用）
+*   **ビデオ結合:** メディアリスト内のすべてのビデオを、単一の`output.mp4`ファイルに書き出します。（FFmpegを利用）
+*   **ビデオ分割:** プレビューの再生位置でクリップを分割します。
 
-## How to Build
+## ビルド方法
 
-1.  Ensure you have the .NET 8 SDK installed.
-2.  Run the following command in the root directory:
+1.  .NET 8 SDKがインストールされていることを確認してください。
+2.  ルートディレクトリで次のコマンドを実行します:
     ```bash
     dotnet build
     ```
 
-## Runtime Dependencies
+## 実行時の依存関係
 
 ### Linux
 
-This application uses `LibVLCSharp` for video playback, which depends on a system-wide installation of LibVLC.
+このアプリケーションはビデオ再生に`LibVLCSharp`を使用しており、システム全体にインストールされたLibVLCに依存しています。
 
-On Debian-based distributions (like Ubuntu), you can install the necessary packages with:
+Debianベースのディストリビューション（Ubuntuなど）では、次のコマンドで必要なパッケージをインストールできます:
 
 ```bash
 sudo apt-get update
@@ -31,4 +32,4 @@ sudo apt-get install -y libvlc-dev libvlc5
 
 ### Windows & macOS
 
-The necessary native libraries for VLC are bundled with the application via NuGet packages and should work out of the box.
+VLCに必要なネイティブライブラリは、NuGetパッケージを介してアプリケーションにバンドルされており、追加設定なしで動作するはずです。

--- a/VideoEditor/EnumConverters.cs
+++ b/VideoEditor/EnumConverters.cs
@@ -1,0 +1,21 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+
+namespace VideoEditor;
+
+public static class EnumConverters
+{
+    public static readonly IValueConverter VideoRotationToString =
+        new FuncValueConverter<VideoRotation, string>(rotation =>
+        {
+            return rotation switch
+            {
+                VideoRotation.None => "None",
+                VideoRotation.Rotate90 => "90°",
+                VideoRotation.Rotate180 => "180°",
+                VideoRotation.Rotate270 => "270°",
+                _ => rotation.ToString()
+            };
+        });
+}

--- a/VideoEditor/ITimelineItem.cs
+++ b/VideoEditor/ITimelineItem.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace VideoEditor;
+
+public interface ITimelineItem
+{
+    /// <summary>
+    /// Gets the duration of the item on the timeline.
+    /// </summary>
+    TimeSpan Duration { get; }
+
+    /// <summary>
+    /// Gets the user-friendly display name for the item.
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// Gets the full path to the source media file.
+    /// </summary>
+    string SourcePath { get; }
+}

--- a/VideoEditor/ImageClip.cs
+++ b/VideoEditor/ImageClip.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+
+namespace VideoEditor;
+
+public class ImageClip : ITimelineItem
+{
+    public string SourcePath { get; }
+    public TimeSpan Duration { get; set; }
+    public string DisplayName { get; }
+
+    public ImageClip(string sourcePath, TimeSpan duration)
+    {
+        if (!File.Exists(sourcePath))
+        {
+            throw new FileNotFoundException("The source image file was not found.", sourcePath);
+        }
+
+        if (duration <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(duration), "Duration must be positive.");
+        }
+
+        SourcePath = sourcePath;
+        Duration = duration;
+        DisplayName = Path.GetFileName(sourcePath);
+    }
+}

--- a/VideoEditor/MainWindow.axaml
+++ b/VideoEditor/MainWindow.axaml
@@ -3,6 +3,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vlc="using:LibVLCSharp.Avalonia"
+        xmlns:local="using:VideoEditor"
         mc:Ignorable="d" d:DesignWidth="1280" d:DesignHeight="720"
         x:Class="VideoEditor.MainWindow"
         Title="VideoEditor">
@@ -14,7 +15,28 @@
                 <Button Content="Add Media" Margin="5" Click="AddMediaButton_Click"/>
                 <Button x:Name="SplitButton" Content="Split Clip" Margin="5,0,5,5" Click="SplitButton_Click"/>
                 <Button x:Name="ExportButton" Content="Export Video" Margin="5,0,5,5" Click="ExportButton_Click"/>
+
+                <!-- Clip Properties Panel -->
+                <Border x:Name="ClipPropertiesPanel" BorderBrush="Gray" BorderThickness="1" Margin="5" Padding="5" IsVisible="False">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="Clip Properties" FontWeight="Bold" Margin="0,0,0,5"/>
+
+                        <TextBlock Text="Rotation:" Margin="0,5,0,2"/>
+                        <ComboBox x:Name="RotationComboBox" SelectionChanged="RotationComboBox_SelectionChanged">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Converter={x:Static local:EnumConverters.VideoRotationToString}}"/>
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+
+                        <TextBlock Text="Speed:" Margin="0,10,0,2"/>
+                        <NumericUpDown x:Name="SpeedUpDown" ValueChanged="SpeedUpDown_ValueChanged"
+                                       Minimum="0.1" Maximum="10.0" Increment="0.1" FormatString="F1"/>
+                    </StackPanel>
+                </Border>
             </StackPanel>
+
             <ListBox x:Name="MediaListBox" Margin="5" SelectionChanged="MediaListBox_SelectionChanged" DisplayMemberBinding="{Binding DisplayName}">
                 <!-- VideoClip objects will be displayed here -->
             </ListBox>

--- a/VideoEditor/MainWindow.axaml.cs
+++ b/VideoEditor/MainWindow.axaml.cs
@@ -7,15 +7,21 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xabe.FFmpeg;
+using System.Text;
+using System.IO;
+using System.Collections.Generic;
+using System.Globalization;
+using Xabe.FFmpeg.Streams;
 
 namespace VideoEditor;
 
 public partial class MainWindow : Window
 {
-    private readonly ObservableCollection<VideoClip> _timelineClips = new();
+    private readonly ObservableCollection<ITimelineItem> _timelineClips = new();
     private readonly LibVLC _libVLC;
     private readonly MediaPlayer _mediaPlayer;
     private Media? _currentMedia;
+    private bool _isUpdatingClipProperties = false;
 
     public MainWindow()
     {
@@ -26,9 +32,10 @@ public partial class MainWindow : Window
         _mediaPlayer = new MediaPlayer(_libVLC);
         VideoView.MediaPlayer = _mediaPlayer;
 
-        // Bind collections to the UI elements
         MediaListBox.ItemsSource = _timelineClips;
         TimelineItemsControl.ItemsSource = _timelineClips;
+
+        RotationComboBox.ItemsSource = Enum.GetValues(typeof(VideoRotation));
     }
 
     protected override void OnClosed(EventArgs e)
@@ -46,11 +53,11 @@ public partial class MainWindow : Window
 
         var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
         {
-            Title = "Open Video Files",
+            Title = "Open Media Files",
             AllowMultiple = true,
             FileTypeFilter = new[]
             {
-                new FilePickerFileType("Video Files") { Patterns = new[] { "*.mp4", "*.mkv", "*.avi", "*.mov" } },
+                new FilePickerFileType("Media Files") { Patterns = new[] { "*.mp4", "*.mkv", "*.avi", "*.mov", "*.png", "*.jpg", "*.jpeg", "*.bmp" } },
                 FilePickerFileTypes.All
             }
         });
@@ -58,34 +65,63 @@ public partial class MainWindow : Window
         foreach (var file in files)
         {
             var path = file.Path.LocalPath;
+            var extension = Path.GetExtension(path).ToLowerInvariant();
             try
             {
-                var mediaInfo = await FFmpeg.GetMediaInfo(path);
-                var duration = mediaInfo.Duration;
-                var clip = new VideoClip(path, TimeSpan.Zero, duration);
-                _timelineClips.Add(clip);
+                if (new[] { ".png", ".jpg", ".jpeg", ".bmp" }.Contains(extension))
+                {
+                    _timelineClips.Add(new ImageClip(path, TimeSpan.FromSeconds(5)));
+                }
+                else
+                {
+                    var mediaInfo = await FFmpeg.GetMediaInfo(path);
+                    var duration = mediaInfo.Duration;
+                    _timelineClips.Add(new VideoClip(path, TimeSpan.Zero, duration));
+                }
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"Error getting media info for {path}: {ex.Message}");
-                // Optionally, show an error to the user
             }
         }
     }
 
     public void MediaListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (e.AddedItems.Count > 0 && e.AddedItems[0] is VideoClip clip)
+        _isUpdatingClipProperties = true;
+        try
         {
-            _currentMedia?.Dispose();
+            if (e.AddedItems.Count > 0 && e.AddedItems[0] is ITimelineItem item)
+            {
+                if (item is VideoClip clip)
+                {
+                    ClipPropertiesPanel.IsVisible = true;
+                    RotationComboBox.SelectedItem = clip.Rotation;
+                    SpeedUpDown.Value = (decimal)clip.Speed;
 
-            // By default, VLC plays the whole file. We need to tell it to play just the clip's segment.
-            // We can do this with media options.
-            _currentMedia = new Media(_libVLC, new Uri(clip.SourcePath),
-                $":start-time={clip.TrimStart.TotalSeconds}",
-                $":stop-time={clip.TrimEnd.TotalSeconds}");
-
-            _mediaPlayer.Play(_currentMedia);
+                    _currentMedia?.Dispose();
+                    _currentMedia = new Media(_libVLC, new Uri(clip.SourcePath),
+                        $":start-time={clip.TrimStart.TotalSeconds}",
+                        $":stop-time={clip.TrimEnd.TotalSeconds}",
+                        $":rate={clip.Speed}");
+                    _mediaPlayer.Play(_currentMedia);
+                }
+                else if (item is ImageClip)
+                {
+                    ClipPropertiesPanel.IsVisible = false;
+                    _mediaPlayer.Stop();
+                    _currentMedia?.Dispose();
+                    _currentMedia = null;
+                }
+            }
+            else
+            {
+                ClipPropertiesPanel.IsVisible = false;
+            }
+        }
+        finally
+        {
+            _isUpdatingClipProperties = false;
         }
     }
 
@@ -93,15 +129,13 @@ public partial class MainWindow : Window
     {
         if (MediaListBox.SelectedItem is not VideoClip selectedClip)
         {
-            Console.WriteLine("Please select a clip to split.");
+            Console.WriteLine("Please select a video clip to split.");
             return;
         }
 
         var playbackTime = TimeSpan.FromMilliseconds(_mediaPlayer.Time);
-        // The actual split time within the source video's full timeline
         var splitPoint = selectedClip.TrimStart + playbackTime;
 
-        // Basic validation: ensure the split point is within the clip's duration and not at the edges.
         if (splitPoint <= selectedClip.TrimStart || splitPoint >= selectedClip.TrimEnd)
         {
             Console.WriteLine("Split point must be within the clip.");
@@ -111,11 +145,9 @@ public partial class MainWindow : Window
         var originalIndex = _timelineClips.IndexOf(selectedClip);
         if (originalIndex == -1) return;
 
-        // Create the two new clips
-        var clipA = new VideoClip(selectedClip.SourcePath, selectedClip.TrimStart, splitPoint);
-        var clipB = new VideoClip(selectedClip.SourcePath, splitPoint, selectedClip.TrimEnd);
+        var clipA = new VideoClip(selectedClip.SourcePath, selectedClip.TrimStart, splitPoint, selectedClip.Rotation, selectedClip.Speed);
+        var clipB = new VideoClip(selectedClip.SourcePath, splitPoint, selectedClip.TrimEnd, selectedClip.Rotation, selectedClip.Speed);
 
-        // Replace the old clip with the two new ones
         _timelineClips.RemoveAt(originalIndex);
         _timelineClips.Insert(originalIndex, clipA);
         _timelineClips.Insert(originalIndex + 1, clipB);
@@ -127,7 +159,7 @@ public partial class MainWindow : Window
     {
         if (_timelineClips.Count == 0)
         {
-            Console.WriteLine("Please add at least one video to the timeline.");
+            Console.WriteLine("Please add at least one item to the timeline.");
             return;
         }
 
@@ -140,35 +172,92 @@ public partial class MainWindow : Window
 
         try
         {
+            // Determine target video properties from the first video clip
+            var firstVideo = _timelineClips.OfType<VideoClip>().FirstOrDefault();
+            string resolution = "1920x1080";
+            string frameRate = "30";
+            if (firstVideo != null)
+            {
+                var mediaInfo = await FFmpeg.GetMediaInfo(firstVideo.SourcePath);
+                var videoStream = mediaInfo.VideoStreams.First();
+                resolution = videoStream.Resolution;
+                frameRate = videoStream.Framerate.ToString(CultureInfo.InvariantCulture);
+            }
+
             var tempClipPaths = new List<string>();
             for (int i = 0; i < _timelineClips.Count; i++)
             {
-                var clip = _timelineClips[i];
+                var item = _timelineClips[i];
                 var tempClipPath = Path.Combine(tempDirectory, $"{i}.mp4");
+                Console.WriteLine($"Processing item {i + 1}/{_timelineClips.Count}: {item.DisplayName}");
 
-                Console.WriteLine($"Trimming clip {i+1}/{_timelineClips.Count}...");
+                IConversion conversion;
+                if (item is VideoClip videoClip)
+                {
+                    conversion = FFmpeg.Conversions.New()
+                        .AddParameter($"-ss {videoClip.TrimStart.TotalSeconds}")
+                        .AddParameter($"-to {videoClip.TrimEnd.TotalSeconds}")
+                        .AddParameter($"-i \"{videoClip.SourcePath}\"");
 
-                var conversion = FFmpeg.Conversions.New()
-                    .AddParameter($"-ss {clip.TrimStart.TotalSeconds}")
-                    .AddParameter($"-to {clip.TrimEnd.TotalSeconds}")
-                    .AddParameter($"-i \"{clip.SourcePath}\"")
-                    .AddParameter("-c:v copy -c:a copy") // Fast, no re-encoding
-                    .SetOutput(tempClipPath);
+                    var videoFilters = new StringBuilder();
+                    if (videoClip.Rotation != VideoRotation.None)
+                    {
+                        switch (videoClip.Rotation)
+                        {
+                            case VideoRotation.Rotate90: videoFilters.Append("transpose=1"); break;
+                            case VideoRotation.Rotate180: videoFilters.Append("transpose=2,transpose=2"); break;
+                            case VideoRotation.Rotate270: videoFilters.Append("transpose=2"); break;
+                        }
+                    }
 
-                await conversion.Start();
+                    bool needsReEncoding = videoFilters.Length > 0 || videoClip.Speed != 1.0f;
+                    if (needsReEncoding)
+                    {
+                        if (videoClip.Speed != 1.0f)
+                        {
+                            if (videoFilters.Length > 0) videoFilters.Append(',');
+                            videoFilters.Append($"setpts={1.0f / videoClip.Speed:F4}*PTS");
+                        }
+                        conversion.AddParameter($"-vf \"{videoFilters}\"");
+                        if (videoClip.Speed != 1.0f)
+                        {
+                            conversion.AddParameter($"-af atempo={videoClip.Speed.ToString(CultureInfo.InvariantCulture)}");
+                        }
+                    }
+                    else
+                    {
+                        conversion.AddParameter("-c:v copy -c:a copy");
+                    }
+                }
+                else if (item is ImageClip imageClip)
+                {
+                    conversion = FFmpeg.Conversions.New()
+                        .AddParameter("-loop 1", true)
+                        .AddParameter($"-i \"{imageClip.SourcePath}\"")
+                        .AddParameter($"-t {imageClip.Duration.TotalSeconds}")
+                        .AddParameter($"-s {resolution}")
+                        .AddParameter($"-r {frameRate}")
+                        .AddParameter("-c:v libx264")
+                        .AddParameter("-pix_fmt yuv420p")
+                        // Create a silent audio track to prevent concatenation issues
+                        .AddParameter("-f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100");
+                }
+                else
+                {
+                    continue; // Skip unknown item types
+                }
+
+                await conversion.SetOutput(tempClipPath).Start();
                 tempClipPaths.Add(tempClipPath);
             }
 
-            Console.WriteLine("All clips trimmed. Concatenating...");
-
+            Console.WriteLine("All items processed. Concatenating...");
             if (tempClipPaths.Count > 1)
             {
-                IConversion conversion = await FFmpeg.Conversions.FromSnippet.Concatenate(outputPath, tempClipPaths.ToArray());
-                await conversion.Start();
+                await FFmpeg.Conversions.FromSnippet.Concatenate(outputPath, tempClipPaths.ToArray());
             }
             else if (tempClipPaths.Count == 1)
             {
-                // If there's only one clip, we just move the trimmed file.
                 File.Move(tempClipPaths.First(), outputPath, true);
             }
 
@@ -180,12 +269,29 @@ public partial class MainWindow : Window
         }
         finally
         {
-            // Clean up temporary files
             if (Directory.Exists(tempDirectory))
             {
                 Directory.Delete(tempDirectory, true);
             }
             ExportButton.IsEnabled = true;
+        }
+    }
+
+    private void RotationComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isUpdatingClipProperties || MediaListBox.SelectedItem is not VideoClip clip || e.AddedItems.Count == 0)
+            return;
+        clip.Rotation = (VideoRotation)e.AddedItems[0]!;
+    }
+
+    private void SpeedUpDown_ValueChanged(object sender, NumericUpDownValueChangedEventArgs e)
+    {
+        if (_isUpdatingClipProperties || MediaListBox.SelectedItem is not VideoClip clip)
+            return;
+        clip.Speed = (float)e.NewValue;
+        if (_mediaPlayer.IsPlaying)
+        {
+            _mediaPlayer.SetRate(clip.Speed);
         }
     }
 }

--- a/VideoEditor/VideoClip.cs
+++ b/VideoEditor/VideoClip.cs
@@ -3,7 +3,15 @@ using System.IO;
 
 namespace VideoEditor;
 
-public class VideoClip
+public enum VideoRotation
+{
+    None,
+    Rotate90,
+    Rotate180,
+    Rotate270
+}
+
+public class VideoClip : ITimelineItem
 {
     /// <summary>
     /// Gets the full path to the source media file.
@@ -21,16 +29,26 @@ public class VideoClip
     public TimeSpan TrimEnd { get; set; }
 
     /// <summary>
-    /// Gets the duration of this clip.
+    /// Gets or sets the rotation to be applied to the video clip.
     /// </summary>
-    public TimeSpan Duration => TrimEnd - TrimStart;
+    public VideoRotation Rotation { get; set; } = VideoRotation.None;
+
+    /// <summary>
+    /// Gets or sets the playback speed of the clip (1.0 is normal speed).
+    /// </summary>
+    public float Speed { get; set; } = 1.0f;
+
+    /// <summary>
+    /// Gets the duration of this clip, adjusted for speed.
+    /// </summary>
+    public TimeSpan Duration => (TrimEnd - TrimStart) / Speed;
 
     /// <summary>
     /// Gets a user-friendly display name for the clip.
     /// </summary>
     public string DisplayName { get; }
 
-    public VideoClip(string sourcePath, TimeSpan trimStart, TimeSpan trimEnd)
+    public VideoClip(string sourcePath, TimeSpan trimStart, TimeSpan trimEnd, VideoRotation rotation = VideoRotation.None, float speed = 1.0f)
     {
         if (!File.Exists(sourcePath))
         {
@@ -47,9 +65,16 @@ public class VideoClip
             throw new ArgumentException("TrimEnd must be greater than TrimStart.", nameof(trimEnd));
         }
 
+        if (speed <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(speed), "Speed must be positive.");
+        }
+
         SourcePath = sourcePath;
         TrimStart = trimStart;
         TrimEnd = trimEnd;
+        Rotation = rotation;
+        Speed = speed;
         DisplayName = Path.GetFileName(sourcePath);
     }
 
@@ -58,6 +83,6 @@ public class VideoClip
     /// </summary>
     public VideoClip CloneWithNewTimes(TimeSpan newTrimStart, TimeSpan newTrimEnd)
     {
-        return new VideoClip(this.SourcePath, newTrimStart, newTrimEnd);
+        return new VideoClip(this.SourcePath, newTrimStart, newTrimEnd, this.Rotation, this.Speed);
     }
 }


### PR DESCRIPTION
This commit introduces several new features to the video editor:

- **Video Rotation:** Clips can now be rotated in 90-degree increments. A `VideoRotation` enum has been added, and the UI now includes a dropdown to select the rotation for a video clip.
- **Speed Control:** The playback speed of video clips can now be adjusted. The UI includes a numeric up/down control to set the speed. The preview player also respects the speed setting.
- **Still Image Support:** Users can now add still images (PNG, JPG, BMP) to the timeline. A default duration of 5 seconds is applied.
- **Unified Timeline:** An `ITimelineItem` interface was introduced to allow both `VideoClip` and `ImageClip` objects to coexist on the timeline.
- **Enhanced Export:** The FFmpeg export logic has been significantly updated to handle these new features. It now applies rotation and speed filters (which requires re-encoding) and can convert still images into video segments compatible with the rest of the timeline for concatenation.
- **UI for Editing:** A new "Clip Properties" panel was added to the UI to host the controls for rotation and speed.
- **README Translation:** The `README.md` file has been translated into Japanese as requested.