### PR TITLE
feat: Add advanced video editing features

### DIFF
--- a/VideoEditor/AudioClip.cs
+++ b/VideoEditor/AudioClip.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+
+namespace VideoEditor;
+
+public class AudioClip : ITimelineItem
+{
+    public string SourcePath { get; }
+    public TimeSpan Duration { get; set; }
+    public string DisplayName { get; }
+    public double Volume { get; set; } = 1.0;
+
+    public AudioClip(string sourcePath, TimeSpan duration)
+    {
+        if (!File.Exists(sourcePath))
+        {
+            throw new FileNotFoundException("The source audio file was not found.", sourcePath);
+        }
+
+        if (duration <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(duration), "Duration must be positive.");
+        }
+
+        SourcePath = sourcePath;
+        Duration = duration;
+        DisplayName = Path.GetFileName(sourcePath);
+    }
+}

--- a/VideoEditor/MainWindow.axaml
+++ b/VideoEditor/MainWindow.axaml
@@ -13,6 +13,7 @@
         <DockPanel Grid.Column="0">
             <StackPanel DockPanel.Dock="Top" Orientation="Vertical">
                 <Button Content="Add Media" Margin="5" Click="AddMediaButton_Click"/>
+                <Button Content="Add Audio" Margin="5,0,5,5" Click="AddAudioButton_Click"/>
                 <Button x:Name="SplitButton" Content="Split Clip" Margin="5,0,5,5" Click="SplitButton_Click"/>
                 <Button x:Name="ExportButton" Content="Export Video" Margin="5,0,5,5" Click="ExportButton_Click"/>
 
@@ -21,18 +22,49 @@
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="Clip Properties" FontWeight="Bold" Margin="0,0,0,5"/>
 
-                        <TextBlock Text="Rotation:" Margin="0,5,0,2"/>
-                        <ComboBox x:Name="RotationComboBox" SelectionChanged="RotationComboBox_SelectionChanged">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding Converter={x:Static local:EnumConverters.VideoRotationToString}}"/>
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
+                        <!-- Video-specific properties -->
+                        <StackPanel x:Name="VideoPropertiesPanel" Orientation="Vertical" IsVisible="False">
+                            <TextBlock Text="Rotation:" Margin="0,5,0,2"/>
+                            <ComboBox x:Name="RotationComboBox" SelectionChanged="RotationComboBox_SelectionChanged">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Converter={x:Static local:EnumConverters.VideoRotationToString}}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
 
-                        <TextBlock Text="Speed:" Margin="0,10,0,2"/>
-                        <NumericUpDown x:Name="SpeedUpDown" ValueChanged="SpeedUpDown_ValueChanged"
-                                       Minimum="0.1" Maximum="10.0" Increment="0.1" FormatString="F1"/>
+                            <TextBlock Text="Flip:" Margin="0,5,0,2"/>
+                            <ComboBox x:Name="FlipComboBox" SelectionChanged="FlipComboBox_SelectionChanged"/>
+
+                            <TextBlock Text="Filter:" Margin="0,5,0,2"/>
+                            <ComboBox x:Name="FilterComboBox" SelectionChanged="FilterComboBox_SelectionChanged"/>
+
+                            <TextBlock Text="Speed:" Margin="0,10,0,2"/>
+                            <NumericUpDown x:Name="SpeedUpDown" ValueChanged="SpeedUpDown_ValueChanged"
+                                           Minimum="0.1" Maximum="10.0" Increment="0.1" FormatString="F1"/>
+
+                            <TextBlock Text="Volume:" Margin="0,10,0,2"/>
+                            <DockPanel>
+                                <TextBlock Text="{Binding #VideoVolumeSlider.Value, StringFormat='{}{0:F2}'}" DockPanel.Dock="Right" Margin="10,0,0,0"/>
+                                <Slider x:Name="VideoVolumeSlider" Minimum="0.0" Maximum="2.0" Value="1.0"
+                                        ValueChanged="VideoVolumeSlider_ValueChanged"/>
+                            </DockPanel>
+
+                            <TextBlock Text="Text Overlays:" FontWeight="Bold" Margin="0,15,0,5"/>
+                            <ListBox x:Name="OverlaysListBox" Height="100" DisplayMemberBinding="{Binding Text}"/>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="5" Margin="0,5,0,0">
+                                <Button Content="Add" Click="AddOverlayButton_Click"/>
+                                <Button Content="Edit" Click="EditOverlayButton_Click"/>
+                                <Button Content="Remove" Click="RemoveOverlayButton_Click"/>
+                            </StackPanel>
+                        </StackPanel>
+
+                        <!-- Image-specific properties -->
+                        <StackPanel x:Name="ImageDurationPanel" Orientation="Vertical" IsVisible="False">
+                            <TextBlock Text="Duration (seconds):" Margin="0,10,0,2"/>
+                            <NumericUpDown x:Name="ImageDurationUpDown" ValueChanged="ImageDurationUpDown_ValueChanged"
+                                           Minimum="0.1" Maximum="3600" Increment="0.5" FormatString="F1"/>
+                        </StackPanel>
                     </StackPanel>
                 </Border>
             </StackPanel>
@@ -43,14 +75,16 @@
         </DockPanel>
 
         <!-- Main Area (Preview and Timeline) -->
-        <Grid Grid.Column="1" RowDefinitions="*, 300">
+        <Grid Grid.Column="1" RowDefinitions="*, 300, 100">
             <!-- Video Preview Panel -->
             <vlc:VideoView x:Name="VideoView" Grid.Row="0" />
 
-            <!-- Timeline Panel -->
+            <!-- Video Timeline Panel -->
             <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="0,1,0,0">
                 <ScrollViewer HorizontalScrollBarVisibility="Auto">
-                    <ItemsControl x:Name="TimelineItemsControl">
+                    <ItemsControl x:Name="TimelineItemsControl" AllowDrop="True"
+                                  DragDrop.DragOver="Timeline_DragOver"
+                                  DragDrop.Drop="Timeline_Drop">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <StackPanel Orientation="Horizontal" />
@@ -59,10 +93,36 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <!-- A simple representation of a video clip -->
-                                <Border BorderBrush="Black" BorderThickness="1" Margin="2" Background="LightSkyBlue" Height="60">
+                                <Border BorderBrush="Black" BorderThickness="1" Margin="2" Background="LightSkyBlue" Height="60"
+                                        PointerPressed="TimelineItem_PointerPressed">
+                                    <StackPanel Orientation="Vertical" Margin="5" IsHitTestVisible="False">
+                                        <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding Duration, StringFormat='Duration: {0:hh\\:mm\\:ss}'}"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Border>
+
+            <!-- Audio Timeline Panel -->
+            <Border Grid.Row="2" BorderBrush="Gray" BorderThickness="0,1,0,0">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto">
+                    <ItemsControl x:Name="AudioTimelineItemsControl">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <!-- A simple representation of an audio clip -->
+                                <Border BorderBrush="Black" BorderThickness="1" Margin="2" Background="LightGreen" Height="60">
                                     <StackPanel Orientation="Vertical" Margin="5">
                                         <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"/>
                                         <TextBlock Text="{Binding Duration, StringFormat='Duration: {0:hh\\:mm\\:ss}'}"/>
+                                        <Slider Minimum="0.0" Maximum="2.0" Value="{Binding Volume, Mode=TwoWay}" Margin="0,5,0,0"/>
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>

--- a/VideoEditor/MainWindow.axaml.cs
+++ b/VideoEditor/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using System.Collections.ObjectModel;
@@ -18,6 +19,7 @@ namespace VideoEditor;
 public partial class MainWindow : Window
 {
     private readonly ObservableCollection<ITimelineItem> _timelineClips = new();
+    private readonly ObservableCollection<AudioClip> _audioClips = new();
     private readonly LibVLC _libVLC;
     private readonly MediaPlayer _mediaPlayer;
     private Media? _currentMedia;
@@ -34,8 +36,11 @@ public partial class MainWindow : Window
 
         MediaListBox.ItemsSource = _timelineClips;
         TimelineItemsControl.ItemsSource = _timelineClips;
+        AudioTimelineItemsControl.ItemsSource = _audioClips;
 
         RotationComboBox.ItemsSource = Enum.GetValues(typeof(VideoRotation));
+        FlipComboBox.ItemsSource = Enum.GetValues(typeof(VideoFlip));
+        FilterComboBox.ItemsSource = Enum.GetValues(typeof(VideoFilterType));
     }
 
     protected override void OnClosed(EventArgs e)
@@ -86,18 +91,60 @@ public partial class MainWindow : Window
         }
     }
 
+    public async void AddAudioButton_Click(object sender, RoutedEventArgs e)
+    {
+        var topLevel = GetTopLevel(this);
+        if (topLevel is null) return;
+
+        var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Open Audio Files",
+            AllowMultiple = true,
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("Audio Files") { Patterns = new[] { "*.mp3", "*.wav", "*.m4a", "*.flac" } },
+                FilePickerFileTypes.All
+            }
+        });
+
+        foreach (var file in files)
+        {
+            var path = file.Path.LocalPath;
+            try
+            {
+                var mediaInfo = await FFmpeg.GetMediaInfo(path);
+                var duration = mediaInfo.Duration;
+                _audioClips.Add(new AudioClip(path, duration));
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error getting media info for {path}: {ex.Message}");
+            }
+        }
+    }
+
     public void MediaListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         _isUpdatingClipProperties = true;
         try
         {
+            ClipPropertiesPanel.IsVisible = false;
+            VideoPropertiesPanel.IsVisible = false;
+            ImageDurationPanel.IsVisible = false;
+            OverlaysListBox.ItemsSource = null;
+
             if (e.AddedItems.Count > 0 && e.AddedItems[0] is ITimelineItem item)
             {
+                ClipPropertiesPanel.IsVisible = true;
                 if (item is VideoClip clip)
                 {
-                    ClipPropertiesPanel.IsVisible = true;
+                    VideoPropertiesPanel.IsVisible = true;
                     RotationComboBox.SelectedItem = clip.Rotation;
+                    FlipComboBox.SelectedItem = clip.Flip;
+                    FilterComboBox.SelectedItem = clip.Filter;
                     SpeedUpDown.Value = (decimal)clip.Speed;
+                    VideoVolumeSlider.Value = clip.Volume;
+                    OverlaysListBox.ItemsSource = clip.Overlays;
 
                     _currentMedia?.Dispose();
                     _currentMedia = new Media(_libVLC, new Uri(clip.SourcePath),
@@ -106,17 +153,15 @@ public partial class MainWindow : Window
                         $":rate={clip.Speed}");
                     _mediaPlayer.Play(_currentMedia);
                 }
-                else if (item is ImageClip)
+                else if (item is ImageClip imageClip)
                 {
-                    ClipPropertiesPanel.IsVisible = false;
+                    ImageDurationPanel.IsVisible = true;
+                    ImageDurationUpDown.Value = (decimal)imageClip.Duration.TotalSeconds;
+
                     _mediaPlayer.Stop();
                     _currentMedia?.Dispose();
                     _currentMedia = null;
                 }
-            }
-            else
-            {
-                ClipPropertiesPanel.IsVisible = false;
             }
         }
         finally
@@ -145,8 +190,9 @@ public partial class MainWindow : Window
         var originalIndex = _timelineClips.IndexOf(selectedClip);
         if (originalIndex == -1) return;
 
-        var clipA = new VideoClip(selectedClip.SourcePath, selectedClip.TrimStart, splitPoint, selectedClip.Rotation, selectedClip.Speed);
-        var clipB = new VideoClip(selectedClip.SourcePath, splitPoint, selectedClip.TrimEnd, selectedClip.Rotation, selectedClip.Speed);
+        var clipA = new VideoClip(selectedClip.SourcePath, selectedClip.TrimStart, splitPoint, selectedClip.Rotation, selectedClip.Speed, selectedClip.Flip, selectedClip.Volume, selectedClip.Filter);
+        clipA.Overlays.AddRange(selectedClip.Overlays); // Copy overlays to the first part
+        var clipB = new VideoClip(selectedClip.SourcePath, splitPoint, selectedClip.TrimEnd, selectedClip.Rotation, selectedClip.Speed, selectedClip.Flip, selectedClip.Volume, selectedClip.Filter);
 
         _timelineClips.RemoveAt(originalIndex);
         _timelineClips.Insert(originalIndex, clipA);
@@ -163,7 +209,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        var outputPath = "output.mp4";
+        var finalOutputPath = "output.mp4";
         var tempDirectory = Path.Combine(Path.GetTempPath(), "VideoEditor_Temp", Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDirectory);
 
@@ -172,7 +218,10 @@ public partial class MainWindow : Window
 
         try
         {
-            // Determine target video properties from the first video clip
+            // --- Step 1: Process and Concatenate Video/Image Clips ---
+            Console.WriteLine("Step 1: Processing visual timeline...");
+            var tempVideoPath = Path.Combine(tempDirectory, "temp_video_with_audio.mp4");
+
             var firstVideo = _timelineClips.OfType<VideoClip>().FirstOrDefault();
             string resolution = "1920x1080";
             string frameRate = "30";
@@ -184,11 +233,11 @@ public partial class MainWindow : Window
                 frameRate = videoStream.Framerate.ToString(CultureInfo.InvariantCulture);
             }
 
-            var tempClipPaths = new List<string>();
+            var tempVisualClipPaths = new List<string>();
             for (int i = 0; i < _timelineClips.Count; i++)
             {
                 var item = _timelineClips[i];
-                var tempClipPath = Path.Combine(tempDirectory, $"{i}.mp4");
+                var tempClipPath = Path.Combine(tempDirectory, $"visual_{i}.mp4");
                 Console.WriteLine($"Processing item {i + 1}/{_timelineClips.Count}: {item.DisplayName}");
 
                 IConversion conversion;
@@ -210,8 +259,53 @@ public partial class MainWindow : Window
                         }
                     }
 
-                    bool needsReEncoding = videoFilters.Length > 0 || videoClip.Speed != 1.0f;
-                    if (needsReEncoding)
+                    if (videoClip.Flip != VideoFlip.None)
+                    {
+                        if (videoFilters.Length > 0) videoFilters.Append(',');
+                        switch (videoClip.Flip)
+                        {
+                            case VideoFlip.Horizontal: videoFilters.Append("hflip"); break;
+                            case VideoFlip.Vertical: videoFilters.Append("vflip"); break;
+                        }
+                    }
+
+                    foreach (var overlay in videoClip.Overlays)
+                    {
+                        if (videoFilters.Length > 0) videoFilters.Append(',');
+                        // Basic text escaping: wrap in single quotes. More complex text would need more robust escaping.
+                        var escapedText = overlay.Text.Replace("'", "'\\''");
+                        videoFilters.Append($"drawtext=text='{escapedText}':x={overlay.X}:y={overlay.Y}:fontsize={overlay.FontSize}:fontcolor={overlay.FontColor}:enable='between(t,{overlay.StartTime.TotalSeconds},{overlay.EndTime.TotalSeconds})'");
+                    }
+
+                    if (videoClip.Filter != VideoFilterType.None)
+                    {
+                        if (videoFilters.Length > 0) videoFilters.Append(',');
+                        switch (videoClip.Filter)
+                        {
+                            case VideoFilterType.Sepia:
+                                videoFilters.Append("colorchannelmixer=.393:.769:.189:0:.349:.686:.168:0:.272:.534:.131");
+                                break;
+                            case VideoFilterType.Monochrome:
+                                videoFilters.Append("colorchannelmixer=.3:.4:.3:0:.3:.4:.3:0:.3:.4:.3");
+                                break;
+                            case VideoFilterType.Vintage:
+                                videoFilters.Append("curves=r='0/0.11 .42/.51 1/0.95':g='0/0 .50/.48 1/1':b='0/0.22 .49/.44 1/0.8'");
+                                break;
+                        }
+                    }
+
+                    var audioFilters = new StringBuilder();
+                    if (videoClip.Speed != 1.0f) audioFilters.Append($"atempo={videoClip.Speed.ToString(CultureInfo.InvariantCulture)}");
+                    if (videoClip.Volume != 1.0)
+                    {
+                        if (audioFilters.Length > 0) audioFilters.Append(',');
+                        audioFilters.Append($"volume={videoClip.Volume.ToString(CultureInfo.InvariantCulture)}");
+                    }
+
+                    bool needsVideoReEncoding = videoFilters.Length > 0 || videoClip.Speed != 1.0f;
+                    bool needsAudioReEncoding = audioFilters.Length > 0;
+
+                    if (needsVideoReEncoding)
                     {
                         if (videoClip.Speed != 1.0f)
                         {
@@ -219,18 +313,24 @@ public partial class MainWindow : Window
                             videoFilters.Append($"setpts={1.0f / videoClip.Speed:F4}*PTS");
                         }
                         conversion.AddParameter($"-vf \"{videoFilters}\"");
-                        if (videoClip.Speed != 1.0f)
-                        {
-                            conversion.AddParameter($"-af atempo={videoClip.Speed.ToString(CultureInfo.InvariantCulture)}");
-                        }
                     }
                     else
                     {
-                        conversion.AddParameter("-c:v copy -c:a copy");
+                        conversion.AddParameter("-c:v copy");
+                    }
+
+                    if(needsAudioReEncoding)
+                    {
+                        conversion.AddParameter($"-af \"{audioFilters}\"");
+                    }
+                    else
+                    {
+                        conversion.AddParameter("-c:a copy");
                     }
                 }
                 else if (item is ImageClip imageClip)
                 {
+                    // ... (same as before)
                     conversion = FFmpeg.Conversions.New()
                         .AddParameter("-loop 1", true)
                         .AddParameter($"-i \"{imageClip.SourcePath}\"")
@@ -239,29 +339,81 @@ public partial class MainWindow : Window
                         .AddParameter($"-r {frameRate}")
                         .AddParameter("-c:v libx264")
                         .AddParameter("-pix_fmt yuv420p")
-                        // Create a silent audio track to prevent concatenation issues
                         .AddParameter("-f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100");
                 }
-                else
-                {
-                    continue; // Skip unknown item types
-                }
+                else continue;
 
                 await conversion.SetOutput(tempClipPath).Start();
-                tempClipPaths.Add(tempClipPath);
+                tempVisualClipPaths.Add(tempClipPath);
             }
 
-            Console.WriteLine("All items processed. Concatenating...");
-            if (tempClipPaths.Count > 1)
+            Console.WriteLine("All visual items processed. Concatenating...");
+            if (tempVisualClipPaths.Count > 1)
             {
-                await FFmpeg.Conversions.FromSnippet.Concatenate(outputPath, tempClipPaths.ToArray());
+                await FFmpeg.Conversions.FromSnippet.Concatenate(tempVideoPath, tempVisualClipPaths.ToArray());
             }
-            else if (tempClipPaths.Count == 1)
+            else if (tempVisualClipPaths.Count == 1)
             {
-                File.Move(tempClipPaths.First(), outputPath, true);
+                File.Move(tempVisualClipPaths.First(), tempVideoPath, true);
             }
 
-            Console.WriteLine($"Export finished! Video saved to: {outputPath}");
+            // --- Step 2: Check for Audio Clips and Mix ---
+            if (_audioClips.Count == 0)
+            {
+                Console.WriteLine("No audio clips to mix. Finalizing video.");
+                File.Move(tempVideoPath, finalOutputPath, true);
+            }
+            else
+            {
+                Console.WriteLine("Step 2: Processing and mixing audio track...");
+                var tempAudioClipPaths = new List<string>();
+                for(int i = 0; i < _audioClips.Count; i++)
+                {
+                    var audioClip = _audioClips[i];
+                    var tempAudioPath = Path.Combine(tempDirectory, $"audio_{i}.m4a");
+                    Console.WriteLine($"Processing audio clip {i+1}/{_audioClips.Count}: {audioClip.DisplayName}");
+
+                    var audioConversion = FFmpeg.Conversions.New()
+                        .AddParameter($"-i \"{audioClip.SourcePath}\"");
+
+                    if(audioClip.Volume != 1.0)
+                    {
+                        audioConversion.AddParameter($"-af \"volume={audioClip.Volume.ToString(CultureInfo.InvariantCulture)}\"");
+                    }
+                    else
+                    {
+                        audioConversion.AddParameter("-c copy");
+                    }
+                    await audioConversion.SetOutput(tempAudioPath).Start();
+                    tempAudioClipPaths.Add(tempAudioPath);
+                }
+
+                var tempAudioConcatPath = Path.Combine(tempDirectory, "concat_audio_list.txt");
+                var tempFullAudioPath = Path.Combine(tempDirectory, "temp_full_audio.m4a");
+                var audioFileNames = tempAudioClipPaths.Select(path => $"file '{path}'").ToList();
+                await File.WriteAllLinesAsync(tempAudioConcatPath, audioFileNames);
+
+                await FFmpeg.Conversions.New()
+                    .AddParameter("-f concat -safe 0")
+                    .AddParameter($"-i \"{tempAudioConcatPath}\"")
+                    .AddParameter("-c copy")
+                    .SetOutput(tempFullAudioPath)
+                    .Start();
+
+                Console.WriteLine("Mixing video and audio tracks...");
+                // Final mixing logic remains the same
+                await FFmpeg.Conversions.New()
+                    .AddParameter($"-i \"{tempVideoPath}\"")
+                    .AddParameter($"-i \"{tempFullAudioPath}\"")
+                    .AddParameter("-filter_complex \"[0:a][1:a]amix=inputs=2:duration=longest[a]\"")
+                    .AddParameter("-map 0:v")
+                    .AddParameter("-map \"[a]\"")
+                    .AddParameter("-c:v copy")
+                    .SetOutput(finalOutputPath)
+                    .Start();
+            }
+
+            Console.WriteLine($"Export finished! Video saved to: {finalOutputPath}");
         }
         catch (Exception ex)
         {
@@ -284,6 +436,20 @@ public partial class MainWindow : Window
         clip.Rotation = (VideoRotation)e.AddedItems[0]!;
     }
 
+    private void FlipComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isUpdatingClipProperties || MediaListBox.SelectedItem is not VideoClip clip || e.AddedItems.Count == 0)
+            return;
+        clip.Flip = (VideoFlip)e.AddedItems[0]!;
+    }
+
+    private void FilterComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isUpdatingClipProperties || MediaListBox.SelectedItem is not VideoClip clip || e.AddedItems.Count == 0)
+            return;
+        clip.Filter = (VideoFilterType)e.AddedItems[0]!;
+    }
+
     private void SpeedUpDown_ValueChanged(object sender, NumericUpDownValueChangedEventArgs e)
     {
         if (_isUpdatingClipProperties || MediaListBox.SelectedItem is not VideoClip clip)
@@ -292,6 +458,158 @@ public partial class MainWindow : Window
         if (_mediaPlayer.IsPlaying)
         {
             _mediaPlayer.SetRate(clip.Speed);
+        }
+    }
+
+    private void VideoVolumeSlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
+    {
+        if (_isUpdatingClipProperties || MediaListBox.SelectedItem is not VideoClip clip)
+            return;
+        clip.Volume = e.NewValue;
+    }
+
+    private void ImageDurationUpDown_ValueChanged(object sender, NumericUpDownValueChangedEventArgs e)
+    {
+        if (_isUpdatingClipProperties || MediaListBox.SelectedItem is not ImageClip clip)
+            return;
+        clip.Duration = TimeSpan.FromSeconds((double)e.NewValue);
+    }
+
+    private async void AddOverlayButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (MediaListBox.SelectedItem is not VideoClip selectedClip)
+        {
+            Console.WriteLine("Please select a video clip first.");
+            return;
+        }
+
+        var newOverlay = new TextOverlay();
+        var editor = new TextOverlayEditorWindow(newOverlay);
+        var result = await editor.ShowDialog<bool>(this);
+
+        if (result)
+        {
+            selectedClip.Overlays.Add(newOverlay);
+            // Refresh the ListBox
+            OverlaysListBox.ItemsSource = null;
+            OverlaysListBox.ItemsSource = selectedClip.Overlays;
+        }
+    }
+
+    private async void EditOverlayButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (MediaListBox.SelectedItem is not VideoClip selectedClip || OverlaysListBox.SelectedItem is not TextOverlay selectedOverlay)
+        {
+            Console.WriteLine("Please select a video clip and a text overlay to edit.");
+            return;
+        }
+
+        var editor = new TextOverlayEditorWindow(selectedOverlay);
+        var result = await editor.ShowDialog<bool>(this);
+
+        if (result)
+        {
+            // Object is edited by reference, just need to refresh UI
+            OverlaysListBox.ItemsSource = null;
+            OverlaysListBox.ItemsSource = selectedClip.Overlays;
+        }
+    }
+
+    private void RemoveOverlayButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (MediaListBox.SelectedItem is not VideoClip selectedClip || OverlaysListBox.SelectedItem is not TextOverlay selectedOverlay)
+        {
+            Console.WriteLine("Please select a video clip and a text overlay to remove.");
+            return;
+        }
+
+        selectedClip.Overlays.Remove(selectedOverlay);
+        // Refresh the ListBox
+        OverlaysListBox.ItemsSource = null;
+        OverlaysListBox.ItemsSource = selectedClip.Overlays;
+    }
+
+    private async void TimelineItem_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is not Border { DataContext: ITimelineItem item }) return;
+
+        var data = new DataObject();
+        data.Set("TimelineItem", item);
+
+        var result = await DragDrop.DoDragDrop(e, data, DragDropEffects.Move);
+
+        if (result == DragDropEffects.Move)
+        {
+            // The drop handler will have already moved the item.
+        }
+    }
+
+    private void Timeline_DragOver(object? sender, DragEventArgs e)
+    {
+        e.DragEffects &= (DragDropEffects.Move | DragDropEffects.Copy);
+        if (!e.Data.Contains("TimelineItem"))
+        {
+            e.DragEffects = DragDropEffects.None;
+        }
+    }
+
+    private void Timeline_Drop(object? sender, DragEventArgs e)
+    {
+        if (!e.Data.Contains("TimelineItem")) return;
+
+        var draggedItem = e.Data.Get("TimelineItem") as ITimelineItem;
+        if (draggedItem == null) return;
+
+        var targetControl = e.Source as Control;
+        if (targetControl == null) return;
+
+        // Find the ItemsControl, which is the drop target
+        var itemsControl = sender as ItemsControl;
+        if (itemsControl == null) return;
+
+        // Find the item we are dropping on top of.
+        // We need to walk up the visual tree from the source control until we find an element
+        // that is a direct child of the ItemsControl's panel.
+        Control? targetItemContainer = null;
+        var current = targetControl;
+        while (current != null)
+        {
+            var parent = current.Parent as Control;
+            if (parent == itemsControl.ItemsPanelRoot)
+            {
+                targetItemContainer = current;
+                break;
+            }
+            if (parent == null || parent == itemsControl) // Stop if we reach the ItemsControl itself or null
+            {
+                break;
+            }
+            current = parent;
+        }
+
+        var oldIndex = _timelineClips.IndexOf(draggedItem);
+        if (oldIndex < 0) return;
+
+        var newIndex = -1;
+
+        if (targetItemContainer?.DataContext is ITimelineItem targetItem)
+        {
+            newIndex = _timelineClips.IndexOf(targetItem);
+        }
+        else
+        {
+            // Dropped on the panel but not on an item, so add to the end.
+            newIndex = _timelineClips.Count - 1;
+        }
+
+        if (newIndex < 0)
+        {
+             newIndex = _timelineClips.Count - 1;
+        }
+
+        if (oldIndex != newIndex)
+        {
+            _timelineClips.Move(oldIndex, newIndex);
         }
     }
 }

--- a/VideoEditor/TextOverlay.cs
+++ b/VideoEditor/TextOverlay.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace VideoEditor;
+
+public class TextOverlay
+{
+    public string Text { get; set; } = "Sample Text";
+    public TimeSpan StartTime { get; set; } = TimeSpan.Zero;
+    public TimeSpan EndTime { get; set; } = TimeSpan.FromSeconds(5);
+    public int X { get; set; } = 10;
+    public int Y { get; set; } = 10;
+    public int FontSize { get; set; } = 24;
+    public string FontColor { get; set; } = "white";
+    // In a real app, you'd want to specify a font file path.
+    // For now, we'll rely on FFmpeg's default font.
+    // public string FontFile { get; set; }
+}

--- a/VideoEditor/TextOverlayEditorWindow.axaml
+++ b/VideoEditor/TextOverlayEditorWindow.axaml
@@ -1,0 +1,54 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
+        x:Class="VideoEditor.TextOverlayEditorWindow"
+        Title="Text Overlay Editor"
+        WindowStartupLocation="CenterOwner"
+        SizeToContent="WidthAndHeight"
+        CanResize="False">
+
+    <StackPanel Orientation="Vertical" Margin="15" Spacing="10">
+        <TextBlock Text="Text Content:"/>
+        <TextBox x:Name="TextContentTextBox" Text="{Binding Text}"/>
+
+        <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" Margin="0,10,0,0">
+            <StackPanel Grid.Row="0" Grid.Column="0" Margin="0,0,5,0">
+                <TextBlock Text="Start Time (s):"/>
+                <NumericUpDown x:Name="StartTimeNumUpDown" Value="{Binding StartTimeSeconds}" Minimum="0" Increment="0.1" FormatString="F1"/>
+            </StackPanel>
+            <StackPanel Grid.Row="0" Grid.Column="1" Margin="5,0,0,0">
+                <TextBlock Text="End Time (s):"/>
+                <NumericUpDown x:Name="EndTimeNumUpDown" Value="{Binding EndTimeSeconds}" Minimum="0" Increment="0.1" FormatString="F1"/>
+            </StackPanel>
+        </Grid>
+
+        <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" Margin="0,10,0,0">
+            <StackPanel Grid.Row="0" Grid.Column="0" Margin="0,0,5,0">
+                <TextBlock Text="X Position:"/>
+                <NumericUpDown x:Name="XPosNumUpDown" Value="{Binding X}" Minimum="0"/>
+            </StackPanel>
+            <StackPanel Grid.Row="0" Grid.Column="1" Margin="5,0,0,0">
+                <TextBlock Text="Y Position:"/>
+                <NumericUpDown x:Name="YPosNumUpDown" Value="{Binding Y}" Minimum="0"/>
+            </StackPanel>
+        </Grid>
+
+        <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" Margin="0,10,0,0">
+            <StackPanel Grid.Row="0" Grid.Column="0" Margin="0,0,5,0">
+                <TextBlock Text="Font Size:"/>
+                <NumericUpDown x:Name="FontSizeNumUpDown" Value="{Binding FontSize}" Minimum="1"/>
+            </StackPanel>
+            <StackPanel Grid.Row="0" Grid.Column="1" Margin="5,0,0,0">
+                <TextBlock Text="Font Color:"/>
+                <TextBox x:Name="FontColorTextBox" Text="{Binding FontColor}"/>
+            </StackPanel>
+        </Grid>
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0" Spacing="10">
+            <Button Content="Save" Click="SaveButton_Click"/>
+            <Button Content="Cancel" Click="CancelButton_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/VideoEditor/TextOverlayEditorWindow.axaml.cs
+++ b/VideoEditor/TextOverlayEditorWindow.axaml.cs
@@ -1,0 +1,48 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using System;
+
+namespace VideoEditor;
+
+public partial class TextOverlayEditorWindow : Window
+{
+    public TextOverlay Overlay { get; }
+
+    // Helper properties for binding TimeSpan to NumericUpDown
+    public decimal StartTimeSeconds
+    {
+        get => (decimal)Overlay.StartTime.TotalSeconds;
+        set => Overlay.StartTime = TimeSpan.FromSeconds((double)value);
+    }
+
+    public decimal EndTimeSeconds
+    {
+        get => (decimal)Overlay.EndTime.TotalSeconds;
+        set => Overlay.EndTime = TimeSpan.FromSeconds((double)value);
+    }
+
+    public TextOverlayEditorWindow()
+    {
+        InitializeComponent();
+        Overlay = new TextOverlay();
+        DataContext = this;
+    }
+
+    public TextOverlayEditorWindow(TextOverlay overlay)
+    {
+        InitializeComponent();
+        Overlay = overlay;
+        DataContext = this;
+    }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        // The bindings should have already updated the Overlay object.
+        Close(true); // Close and return true result
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        Close(false); // Close and return false result
+    }
+}

--- a/VideoEditor/VideoClip.cs
+++ b/VideoEditor/VideoClip.cs
@@ -11,6 +11,21 @@ public enum VideoRotation
     Rotate270
 }
 
+public enum VideoFlip
+{
+    None,
+    Horizontal,
+    Vertical
+}
+
+public enum VideoFilterType
+{
+    None,
+    Sepia,
+    Monochrome,
+    Vintage
+}
+
 public class VideoClip : ITimelineItem
 {
     /// <summary>
@@ -34,9 +49,29 @@ public class VideoClip : ITimelineItem
     public VideoRotation Rotation { get; set; } = VideoRotation.None;
 
     /// <summary>
+    /// Gets or sets the flip to be applied to the video clip.
+    /// </summary>
+    public VideoFlip Flip { get; set; } = VideoFlip.None;
+
+    /// <summary>
     /// Gets or sets the playback speed of the clip (1.0 is normal speed).
     /// </summary>
     public float Speed { get; set; } = 1.0f;
+
+    /// <summary>
+    /// Gets or sets the volume of the clip's audio (0.0 to 1.0).
+    /// </summary>
+    public double Volume { get; set; } = 1.0;
+
+    /// <summary>
+    /// Gets or sets the list of text overlays for this clip.
+    /// </summary>
+    public List<TextOverlay> Overlays { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the visual filter to be applied to the video clip.
+    /// </summary>
+    public VideoFilterType Filter { get; set; } = VideoFilterType.None;
 
     /// <summary>
     /// Gets the duration of this clip, adjusted for speed.
@@ -48,7 +83,7 @@ public class VideoClip : ITimelineItem
     /// </summary>
     public string DisplayName { get; }
 
-    public VideoClip(string sourcePath, TimeSpan trimStart, TimeSpan trimEnd, VideoRotation rotation = VideoRotation.None, float speed = 1.0f)
+    public VideoClip(string sourcePath, TimeSpan trimStart, TimeSpan trimEnd, VideoRotation rotation = VideoRotation.None, float speed = 1.0f, VideoFlip flip = VideoFlip.None, double volume = 1.0, VideoFilterType filter = VideoFilterType.None)
     {
         if (!File.Exists(sourcePath))
         {
@@ -75,6 +110,9 @@ public class VideoClip : ITimelineItem
         TrimEnd = trimEnd;
         Rotation = rotation;
         Speed = speed;
+        Flip = flip;
+        Volume = volume;
+        Filter = filter;
         DisplayName = Path.GetFileName(sourcePath);
     }
 
@@ -83,6 +121,9 @@ public class VideoClip : ITimelineItem
     /// </summary>
     public VideoClip CloneWithNewTimes(TimeSpan newTrimStart, TimeSpan newTrimEnd)
     {
-        return new VideoClip(this.SourcePath, newTrimStart, newTrimEnd, this.Rotation, this.Speed);
+        var newClip = new VideoClip(this.SourcePath, newTrimStart, newTrimEnd, this.Rotation, this.Speed, this.Flip, this.Volume, this.Filter);
+        // Perform a shallow copy of the overlays. For a more robust solution, deep cloning might be needed.
+        newClip.Overlays.AddRange(this.Overlays);
+        return newClip;
     }
 }


### PR DESCRIPTION
This commit introduces a comprehensive set of new features to the video editor, significantly enhancing its capabilities.

New features include:

- **Audio Track Management**: A dedicated audio track has been added to the timeline. Users can add multiple audio clips (e.g., background music) and adjust their individual volumes.
- **Text Overlays**: Users can now add, edit, and remove text overlays on video clips. A dedicated editor window allows for customizing the text content, timing, position, and color.
- **Video Effects**: Basic video filters (Sepia, Monochrome, Vintage) and a video flip (Horizontal/Vertical) capability have been added to the clip properties panel.
- **Timeline Drag & Drop**: Clips on the video timeline can now be reordered using drag and drop for a more intuitive editing workflow.
- **Image Clip Duration**: The duration of still image clips can now be edited in the properties panel.

The export process has been significantly updated to correctly process and apply all these new properties (volume, effects, text) using FFmpeg, ensuring that the final output matches the user's edits.