### PR TITLE
Fix build: Add missing using directives for List and RangeBaseValueCh…

### DIFF
--- a/VideoEditor/MainWindow.axaml.cs
+++ b/VideoEditor/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;

--- a/VideoEditor/VideoClip.cs
+++ b/VideoEditor/VideoClip.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace VideoEditor;


### PR DESCRIPTION
…angedEventArgs

Resolves two CS0246 build errors:
- "The type or namespace name 'List<>' could not be found" in VideoClip.cs is fixed by adding `using System.Collections.Generic;`.
- "The type or namespace name 'RangeBaseValueChangedEventArgs' could not be found" in MainWindow.axaml.cs is fixed by adding `using Avalonia.Controls.Primitives;`.