### PR TITLE
fix(deps): Add VideoLAN.LibVLC.Windows package

### DIFF
--- a/VideoEditor/VideoEditor.csproj
+++ b/VideoEditor/VideoEditor.csproj
@@ -20,6 +20,7 @@
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="LibVLCSharp.Avalonia" Version="3.9.4" />
+    <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.21" />
     <PackageReference Include="Xabe.FFmpeg" Version="6.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The application was failing at startup with a `LibVLCSharp.Shared.VLCException` because the native LibVLC libraries (`libvlc.dll`, `libvlccore.dll`) could not be found.

The `LibVLCSharp.Avalonia` package provides the bindings for Avalonia but does not include the native binaries.

This change adds a `PackageReference` to `VideoLAN.LibVLC.Windows`, which provides the required native libraries for the Windows platform, ensuring they are copied to the output directory and can be loaded at runtime.