### PR TITLE
Fix video import and timeline display issues

### DIFF
--- a/VideoEditor/MainWindow.axaml.cs
+++ b/VideoEditor/MainWindow.axaml.cs
@@ -83,6 +83,11 @@ public partial class MainWindow : Window
                 {
                     var mediaInfo = await FFmpeg.GetMediaInfo(path);
                     var duration = mediaInfo.Duration;
+                    if (duration <= TimeSpan.Zero)
+                    {
+                        Console.WriteLine($"[ERROR] Media file '{Path.GetFileName(path)}' has a duration of zero or less and will be skipped.");
+                        continue;
+                    }
                     _mediaLibrary.Add(new VideoClip(path, TimeSpan.Zero, duration));
                 }
             }

--- a/VideoEditor/VideoEditor.csproj
+++ b/VideoEditor/VideoEditor.csproj
@@ -21,6 +21,6 @@
     </PackageReference>
     <PackageReference Include="LibVLCSharp.Avalonia" Version="3.9.4" />
     <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.21" />
-    <PackageReference Include="Xabe.FFmpeg" Version="6.0.2" />
+    <PackageReference Include="Xabe.FFmpeg" Version="5.2.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This commit addresses two issues:

1.  A `System.IO.FileNotFoundException` related to `System.Text.Json` was occurring when getting media info. This was caused by `Xabe.FFmpeg` v6.0.2 having a dependency on a preview version of .NET 9. The fix was to downgrade `Xabe.FFmpeg` to the more stable version `5.2.6`.

2.  Videos were reportedly not appearing on the timeline after being added. This was traced to a silent failure when importing videos with a reported duration of zero. The `VideoClip` constructor would throw an exception, which was caught, but the user was not notified. The fix is to add an explicit check for zero-duration videos in `MainWindow.axaml.cs` and log an error to the console, preventing the file from being added to the media library.